### PR TITLE
Nifi 245 maven plugin releases

### DIFF
--- a/nar-maven-plugin/pom.xml
+++ b/nar-maven-plugin/pom.xml
@@ -163,17 +163,24 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.1</version>
-                    <configuration>
-                        <arguments>-P apache-release,check-licenses</arguments>
-                        <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <goals>clean compile javadoc:aggregate deploy</goals>
-                        <preparationGoals>clean compile javadoc:aggregate verify</preparationGoals>
-                        <tagNameFormat>@{project.version}</tagNameFormat>
-                        <releaseProfiles>seal-jars</releaseProfiles>
-                        <useReleaseProfile>false</useReleaseProfile>
-                        <pushChanges>false</pushChanges>
-                        <localCheckout>true</localCheckout>
-                    </configuration>
+                    <executions>
+                      <execution>
+                        <id>default</id>
+                        <goals>
+                          <goal>prepare</goal>
+                          <goal>perform</goal>
+                        </goals>
+                        <configuration>
+                          <pomFileName>platform/pom.xml</pomFileName>
+                          <arguments>-P apache-release,check-licenses</arguments>
+                          <autoVersionSubmodules>true</autoVersionSubmodules>
+                          <goals>deploy</goals>
+                          <tagNameFormat>@{project.version}</tagNameFormat>
+                          <pushChanges>false</pushChanges>
+                          <localCheckout>true</localCheckout>
+                        </configuration>
+                      </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/nar-maven-plugin/pom.xml
+++ b/nar-maven-plugin/pom.xml
@@ -174,6 +174,7 @@
                           <pomFileName>platform/pom.xml</pomFileName>
                           <arguments>-P apache-release,check-licenses</arguments>
                           <autoVersionSubmodules>true</autoVersionSubmodules>
+                          <releaseProfiles>apache-release</releaseProfiles>
                           <goals>deploy</goals>
                           <tagNameFormat>@{project.version}</tagNameFormat>
                           <pushChanges>false</pushChanges>

--- a/nar-maven-plugin/pom.xml
+++ b/nar-maven-plugin/pom.xml
@@ -176,7 +176,7 @@
                           <autoVersionSubmodules>true</autoVersionSubmodules>
                           <releaseProfiles>apache-release</releaseProfiles>
                           <goals>deploy</goals>
-                          <tagNameFormat>@{project.version}</tagNameFormat>
+                          <tagNameFormat>nar-maven-plugin-@{project.version}</tagNameFormat>
                           <pushChanges>false</pushChanges>
                           <localCheckout>true</localCheckout>
                         </configuration>


### PR DESCRIPTION
Set up the maven-release-plugin configuration in the nar-maven-plugin directory to wire up the full process.

1.  Set up the the  release plugin to cope with the plugin's location in a subdirectory.
2.  Activate the apache-release profile, which automatically builds the source-release artifact.
