### PR TITLE
NIFI - 121

### DIFF
--- a/nar-bundles/standard-bundle/standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
+++ b/nar-bundles/standard-bundle/standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
@@ -641,6 +641,11 @@ public class MergeContent extends AbstractSessionFactoryProcessor {
 
         @Override
         public FlowFile merge(final ProcessContext context, final ProcessSession session, final List<FlowFileSessionWrapper> wrappers) {
+            if(wrappers.size() == 1){
+                FlowFileSessionWrapper wrapper = wrappers.get(0);
+                return wrapper.getSession().clone(wrapper.getFlowFile());
+            }
+
             final Set<FlowFile> parentFlowFiles = new HashSet<>();
             for (final FlowFileSessionWrapper wrapper : wrappers) {
                 parentFlowFiles.add(wrapper.getFlowFile());


### PR DESCRIPTION
When MergeContent is configured to perform Binary Concatenation, if
generating bundle of 1 FlowFile, should just Clone original FLowFile
instead of copying data

This is more efficient.