### PR TITLE
Documentation contributing

### DIFF
--- a/nifi/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -1943,7 +1943,7 @@ the same environment, Java ClassLoaders quickly
 become a concern. If multiple components have a dependency on the same
 library but each depends on a different
 version, many problems arise, typically resulting in unexpected
-behavior or `NoClassDefFoudnError` errors occurring.
+behavior or `NoClassDefFoundError` errors occurring.
 In order to prevent these issues from becoming problematic, NiFi
 introduces the notion of a NiFi Archive, or NAR.
 

--- a/nifi/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -2108,6 +2108,7 @@ or you can dig into any of the tickets for creating Processors. Processors shoul
 outside components (except for Controller Services), so they make for excellent starting points for new NiFi developers to
 get started. This exposes the developer to the NiFi API and is the most extensible part of the dataflow system.
 
+System-level and overview documentation is located in '<code checkout location>/nifi/nifi-docs/src/main/asciidoc'.
 Tools available to facilitate documentation generation are available at link:http://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[Editing AsciiDoc with Live Preview].
 
 

--- a/nifi/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -2101,7 +2101,7 @@ among others. We make use of Apache Maven for our builds and Git for our version
 
 === Where to Start?
 
-link:http://issues.apache.org/jira/browse/NIFI[NiFi's Jira page] can be used to find tickets that are tagged as "beginner",
+link:http://issues.apache.org/jira/browse/NIFI[NiFi's JIRA page] can be used to find tickets that are tagged as "beginner",
 or you can dig into any of the tickets for creating Processors. Processors should be self-contained and not rely on other
 outside components (except for Controller Services), so they make for excellent starting points for new NiFi developers to
 get started. This exposes the developer to the NiFi API and is the most extensible part of the dataflow system.

--- a/nifi/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -2098,6 +2098,8 @@ The back end of Apache NiFi is written in Java. The web tier makes use of JAX-RS
 used to provide a user interface. We depend on several third-party JavaScript libraries, including D3 and JQuery,
 among others. We make use of Apache Maven for our builds and Git for our version control system.
 
+Documentation is created in link:http://asciidoctor.org[AsciiDoc]. 
+
 
 === Where to Start?
 
@@ -2105,6 +2107,8 @@ link:http://issues.apache.org/jira/browse/NIFI[NiFi's JIRA page] can be used to 
 or you can dig into any of the tickets for creating Processors. Processors should be self-contained and not rely on other
 outside components (except for Controller Services), so they make for excellent starting points for new NiFi developers to
 get started. This exposes the developer to the NiFi API and is the most extensible part of the dataflow system.
+
+Tools available to facilitate documentation generation are available at link:http://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[Editing AsciiDoc with Live Preview].
 
 
 === Supplying a contribution


### PR DESCRIPTION
Corrected casing of JIRA and fixed NoClassDefFoundError typo.

Adding AsciiDoc as a technology used and then providing a link to tooling to aid in the documentation generation process.
