### PR TITLE
NiFi 327 - Add Processor dialog improper HTML encoding of processor descriptions

### DIFF
--- a/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas-toolbox.js
+++ b/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas-toolbox.js
@@ -975,7 +975,7 @@ nf.CanvasToolbox = (function () {
                         if (nf.Common.isBlank(processorType.description)) {
                             $('#processor-type-description').attr('title', '').html('<span class="unset">No description specified</span>');
                         } else {
-                            $('#processor-type-description').text(processorType.description).ellipsis();
+                            $('#processor-type-description').html(processorType.description).ellipsis();
                         }
 
                         // populate the dom


### PR DESCRIPTION
Treating description as HTML as it has been properly escaped when added to the SlickGrid DataView.

Closes NiFi 327 - https://issues.apache.org/jira/browse/NIFI-327