### PR TITLE
NIFI-344 - Remote processor group lets you specify protocols other than http/https

### DIFF
--- a/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/RemoteProcessGroupResource.java
+++ b/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/RemoteProcessGroupResource.java
@@ -370,6 +370,10 @@ public class RemoteProcessGroupResource extends ApplicationResource {
         if (uri.getScheme() == null || uri.getHost() == null) {
             throw new IllegalArgumentException("The specified remote process group URL is malformed: " + requestProcessGroupDTO.getTargetUri());
         }
+        
+        if (!(uri.getScheme().equalsIgnoreCase("http") || uri.getScheme().equalsIgnoreCase("https"))) {
+            throw new IllegalArgumentException("The specified remote process group URL is invalid, only http and https are supported: " + requestProcessGroupDTO.getTargetUri());
+        }
 
         // normalize the uri to the other controller
         String controllerUri = uri.toString();
@@ -859,6 +863,10 @@ public class RemoteProcessGroupResource extends ApplicationResource {
             // validate each part of the uri
             if (uri.getScheme() == null || uri.getHost() == null) {
                 throw new IllegalArgumentException("The specified remote process group URL is malformed: " + requestRemoteProcessGroup.getTargetUri());
+            }
+            
+            if (!(uri.getScheme().equalsIgnoreCase("http") || uri.getScheme().equalsIgnoreCase("https"))) {
+                throw new IllegalArgumentException("The specified remote process group URL is invalid, only http and https are supported: " + requestRemoteProcessGroup.getTargetUri());
             }
 
             // normalize the uri to the other controller

--- a/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/RemoteProcessGroupResource.java
+++ b/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/RemoteProcessGroupResource.java
@@ -372,7 +372,7 @@ public class RemoteProcessGroupResource extends ApplicationResource {
         }
         
         if (!(uri.getScheme().equalsIgnoreCase("http") || uri.getScheme().equalsIgnoreCase("https"))) {
-            throw new IllegalArgumentException("The specified remote process group URL is invalid, only http and https are supported: " + requestProcessGroupDTO.getTargetUri());
+            throw new IllegalArgumentException("The specified remote process group URL is invalid because it is not http or https: " + requestProcessGroupDTO.getTargetUri());
         }
 
         // normalize the uri to the other controller
@@ -866,7 +866,7 @@ public class RemoteProcessGroupResource extends ApplicationResource {
             }
             
             if (!(uri.getScheme().equalsIgnoreCase("http") || uri.getScheme().equalsIgnoreCase("https"))) {
-                throw new IllegalArgumentException("The specified remote process group URL is invalid, only http and https are supported: " + requestRemoteProcessGroup.getTargetUri());
+                throw new IllegalArgumentException("The specified remote process group URL is invalid because it is not http or https: " + requestRemoteProcessGroup.getTargetUri());
             }
 
             // normalize the uri to the other controller

--- a/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/new-remote-process-group-dialog.jsp
+++ b/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/new-remote-process-group-dialog.jsp
@@ -20,7 +20,7 @@
         <div class="setting">
             <div class="setting-name">URL</div>
             <div class="setting-field">
-                <input id="new-remote-process-group-uri" type="text" placeholder="https://"/>
+                <input id="new-remote-process-group-uri" type="text" placeholder="https://remotehost:8080/nifi"/>
             </div>
         </div>
     </div>

--- a/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/new-remote-process-group-dialog.jsp
+++ b/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/new-remote-process-group-dialog.jsp
@@ -20,7 +20,7 @@
         <div class="setting">
             <div class="setting-name">URL</div>
             <div class="setting-field">
-                <input id="new-remote-process-group-uri" type="text"/>
+                <input id="new-remote-process-group-uri" type="text" placeholder="https://"/>
             </div>
         </div>
     </div>


### PR DESCRIPTION
On the front end, providing a placeHolder hint as to what the expected value looks like
On the back end validating that the user specified url(on create or update) is http://something or https://something