### PR TITLE
Correcting improper reference to Xpath in EvaluateJsonPath usage documentation

### DIFF
--- a/nifi/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.EvaluateJsonPath/index.html
+++ b/nifi/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.EvaluateJsonPath/index.html
@@ -43,7 +43,7 @@
     result evaluations in memory. Accordingly, it is important to consider the anticipated profile of content being
     evaluated by this processor and the hardware supporting it especially when working against large JSON documents.
 </p>
-<S></S>
+
 <p>
     <strong>Properties:</strong>
 </p>

--- a/nifi/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.EvaluateJsonPath/index.html
+++ b/nifi/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.EvaluateJsonPath/index.html
@@ -43,7 +43,7 @@
     result evaluations in memory. Accordingly, it is important to consider the anticipated profile of content being
     evaluated by this processor and the hardware supporting it especially when working against large JSON documents.
 </p>
-
+<S></S>
 <p>
     <strong>Properties:</strong>
 </p>
@@ -89,7 +89,7 @@
     <li>
         <strong>Return Type</strong>
         <ul>
-            <li>Indicates the desired return type of the Xpath expressions.
+            <li>Indicates the desired return type of the JsonPath expressions.
                 Selecting 'auto-detect' will set the return type to 'json' for a
                 Destination of 'flowfile-content', and 'scalar' for a Destination of
                 'flowfile-attribute'.")


### PR DESCRIPTION
I did not make a JIRA issue, if one is needed, let me know and I can update this PR to include it.

This simply corrects a reference to Xpath from using the EvaluateXpath usage guide as a template for  EvaluateJsonPath.