### PR TITLE
NIFI-416 Prefer JAVA_HOME over default java binary in RunNiFi

### DIFF
--- a/nifi/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/RunNiFi.java
+++ b/nifi/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/RunNiFi.java
@@ -65,6 +65,7 @@ import java.util.logging.Level;
 public class RunNiFi {
 	public static final String DEFAULT_CONFIG_FILE = "./conf/bootstrap.conf";
 	public static final String DEFAULT_NIFI_PROPS_FILE = "./conf/nifi.properties";
+	public static final String DEFAULT_JAVA_CMD = "java";
 
 	public static final String GRACEFUL_SHUTDOWN_PROP = "graceful.shutdown.seconds";
 	public static final String DEFAULT_GRACEFUL_SHUTDOWN_VALUE = "20";
@@ -675,8 +676,18 @@ public class RunNiFi {
 
 		final String classPath = classPathBuilder.toString();
 		String javaCmd = props.get("java");
-		if ( javaCmd == null ) {
-			javaCmd = "java";
+		if (javaCmd == null) {
+			javaCmd = DEFAULT_JAVA_CMD;
+		}
+		if (javaCmd.equals(DEFAULT_JAVA_CMD)) {
+			String javaHome = System.getenv("JAVA_HOME");
+			if (javaHome != null) {
+				File javaFile = new File(javaHome + File.separatorChar + "bin"
+					+ File.separatorChar + "java");
+				if (javaFile.exists() && javaFile.canExecute()) {
+					javaCmd = javaFile.getAbsolutePath();
+				}
+			}
 		}
 		
 		final NiFiListener listener = new NiFiListener();


### PR DESCRIPTION
If JAVA_HOME is set and the java command in bootstrap.conf is default, prefer using JAVA_HOME/bin/java.