### PR TITLE
NIFI-460 deprecating createControllerServiceExistsValidator

### DIFF
--- a/nifi/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
+++ b/nifi/nifi-commons/nifi-processor-utilities/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
@@ -615,6 +615,14 @@ public class StandardValidators {
         }
     }
 
+    /**
+     * Creates a validator based on existence of a {@link ControllerService}.
+     * 
+     * @param serviceClass the controller service API your {@link ConfigurableComponent} depends on
+     * @return a Validator
+     * @deprecated As of release 0.1.0-incubating, replaced by {@link org.apache.nifi.components.PropertyDescriptor.Builder#identifiesControllerService(Class)}
+     */
+    @Deprecated
     public static Validator createControllerServiceExistsValidator(final Class<? extends ControllerService> serviceClass) {
         return new Validator() {
             @Override

--- a/nifi/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -85,19 +85,10 @@ public final class InvokeHTTP extends AbstractProcessor {
     //-- properties --//
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        Set<String> contextIdentifiers = getControllerServiceLookup().getControllerServiceIdentifiers(SSLContextService.class);
 
-        PropertyDescriptor contextServiceSelector = new PropertyDescriptor.Builder()
-                .fromPropertyDescriptor(Config.PROP_SSL_CONTEXT_SERVICE)
-                .allowableValues(contextIdentifiers)
-                .build();
-
-        List<PropertyDescriptor> list = new ArrayList<>(Config.PROPERTIES);
-        list.add(2, contextServiceSelector);
-
-        return Collections.unmodifiableList(list);
+        return Config.PROPERTIES;
     }
-
+    
     @Override
     protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(String propertyDescriptorName) {
         if (Config.PROP_TRUSTED_HOSTNAME.getName().equalsIgnoreCase(propertyDescriptorName)) {
@@ -248,23 +239,23 @@ public final class InvokeHTTP extends AbstractProcessor {
                 .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
                 .build();
 
+        PropertyDescriptor PROP_SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
+                .name("SSL Context Service")
+                .description("The SSL Context Service used to provide client certificate information for TLS/SSL (https) connections.")
+                .required(false)
+                .identifiesControllerService(SSLContextService.class)
+                .build();
+        
         List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
                 PROP_METHOD,
                 PROP_URL,
+                PROP_SSL_CONTEXT_SERVICE,
                 PROP_CONNECT_TIMEOUT,
                 PROP_READ_TIMEOUT,
                 PROP_DATE_HEADER,
                 PROP_FOLLOW_REDIRECTS,
                 PROP_ATTRIBUTES_TO_SEND
         ));
-
-        // The allowableValues of the SSL Context Service property is dynamically populated at run time.
-        PropertyDescriptor PROP_SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
-                .name("SSL Context Service")
-                .description("The SSL Context Service used to provide client certificate information for TLS/SSL (https) connections.")
-                .required(false)
-                .addValidator(StandardValidators.createControllerServiceExistsValidator(SSLContextService.class))
-                .build();
 
         // property to allow the hostname verifier to be overridden
         // this is a "hidden" property - it's configured using a dynamic user property


### PR DESCRIPTION
modified InvokeHTTP to use the new mechanism for connecting to ControllerServices.

deprecating StandardValidators.createControllerServiceExistsValidator()