### PR TITLE
NIFI-548 - Listen UDP should support generation of a flowfile per datagram

### DIFF
--- a/nifi/nifi-commons/nifi-socket-utils/src/main/java/org/apache/nifi/io/nio/ChannelListener.java
+++ b/nifi/nifi-commons/nifi-socket-utils/src/main/java/org/apache/nifi/io/nio/ChannelListener.java
@@ -75,14 +75,14 @@ public final class ChannelListener {
     private volatile long channelReaderFrequencyMSecs = 50;
 
     public ChannelListener(final int threadPoolSize, final StreamConsumerFactory consumerFactory, final BufferPool bufferPool, int timeout,
-            TimeUnit unit) throws IOException {
+            TimeUnit unit, final boolean readSingleDatagram) throws IOException {
         this.executor = Executors.newScheduledThreadPool(threadPoolSize + 1); // need to allow for long running ChannelDispatcher thread
         this.serverSocketSelector = Selector.open();
         this.socketChannelSelector = Selector.open();
         this.bufferPool = bufferPool;
         this.initialBufferPoolSize = bufferPool.size();
         channelDispatcher = new ChannelDispatcher(serverSocketSelector, socketChannelSelector, executor, consumerFactory, bufferPool,
-                timeout, unit);
+                timeout, unit, readSingleDatagram);
         executor.schedule(channelDispatcher, 50, TimeUnit.MILLISECONDS);
     }
 

--- a/nifi/nifi-commons/nifi-socket-utils/src/main/java/org/apache/nifi/io/nio/DatagramChannelReader.java
+++ b/nifi/nifi-commons/nifi-socket-utils/src/main/java/org/apache/nifi/io/nio/DatagramChannelReader.java
@@ -27,8 +27,12 @@ public final class DatagramChannelReader extends AbstractChannelReader {
 
     public static final int MAX_UDP_PACKET_SIZE = 65507;
 
-    public DatagramChannelReader(final String id, final SelectionKey key, final BufferPool empties, final StreamConsumerFactory consumerFactory) {
+    private final boolean readSingleDatagram;
+
+    public DatagramChannelReader(final String id, final SelectionKey key, final BufferPool empties, final StreamConsumerFactory consumerFactory,
+            final boolean readSingleDatagram) {
         super(id, key, empties, consumerFactory);
+        this.readSingleDatagram = readSingleDatagram;
     }
 
     /**
@@ -45,7 +49,7 @@ public final class DatagramChannelReader extends AbstractChannelReader {
         final DatagramChannel dChannel = (DatagramChannel) key.channel();
         final int initialBufferPosition = buffer.position();
         while (buffer.remaining() > MAX_UDP_PACKET_SIZE && key.isValid() && key.isReadable()) {
-            if (dChannel.receive(buffer) == null) {
+            if (dChannel.receive(buffer) == null || readSingleDatagram) {
                 break;
             }
         }

--- a/nifi/nifi-commons/nifi-socket-utils/src/test/java/org/apache/nifi/io/nio/example/ServerMain.java
+++ b/nifi/nifi-commons/nifi-socket-utils/src/test/java/org/apache/nifi/io/nio/example/ServerMain.java
@@ -52,7 +52,7 @@ public final class ServerMain {
         ChannelListener listener = null;
         try {
             executor.scheduleWithFixedDelay(bufferPool, 0L, 5L, TimeUnit.SECONDS);
-            listener = new ChannelListener(5, new ExampleStreamConsumerFactory(executor, consumerMap), bufferPool, 5, TimeUnit.MILLISECONDS);
+            listener = new ChannelListener(5, new ExampleStreamConsumerFactory(executor, consumerMap), bufferPool, 5, TimeUnit.MILLISECONDS, false);
             listener.setChannelReaderSchedulingPeriod(50L, TimeUnit.MILLISECONDS);
             listener.addDatagramChannel(null, 20000, 32 << 20);
             LOGGER.info("Listening for UDP data on port 20000");

--- a/nifi/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/UDPStreamConsumer.java
+++ b/nifi/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/UDPStreamConsumer.java
@@ -54,11 +54,12 @@ public class UDPStreamConsumer implements StreamConsumer {
     private ProcessSession session;
     private final UDPConsumerCallback udpCallback;
 
-    public UDPStreamConsumer(final String streamId, final List<FlowFile> newFlowFiles, final long fileSizeTrigger, final ProcessorLog logger) {
+    public UDPStreamConsumer(final String streamId, final List<FlowFile> newFlowFiles, final long fileSizeTrigger, final ProcessorLog logger,
+            final boolean flowFilePerDatagram) {
         this.uniqueId = streamId;
         this.newFlowFileQueue = newFlowFiles;
         this.logger = logger;
-        this.udpCallback = new UDPConsumerCallback(filledBuffers, fileSizeTrigger);
+        this.udpCallback = new UDPConsumerCallback(filledBuffers, fileSizeTrigger, flowFilePerDatagram);
     }
 
     @Override
@@ -173,10 +174,12 @@ public class UDPStreamConsumer implements StreamConsumer {
         BufferPool bufferPool;
         final BlockingQueue<ByteBuffer> filledBuffers;
         final long fileSizeTrigger;
+        final boolean flowFilePerDatagram;
 
-        public UDPConsumerCallback(final BlockingQueue<ByteBuffer> filledBuffers, final long fileSizeTrigger) {
+        public UDPConsumerCallback(final BlockingQueue<ByteBuffer> filledBuffers, final long fileSizeTrigger, final boolean flowFilePerDatagram) {
             this.filledBuffers = filledBuffers;
             this.fileSizeTrigger = fileSizeTrigger;
+            this.flowFilePerDatagram = flowFilePerDatagram;
         }
 
         public void setBufferPool(BufferPool pool) {
@@ -196,7 +199,7 @@ public class UDPStreamConsumer implements StreamConsumer {
                                 bytesWrittenThisPass += wbc.write(buffer);
                             }
                             totalBytes += bytesWrittenThisPass;
-                            if (totalBytes > fileSizeTrigger) {
+                            if (totalBytes > fileSizeTrigger || flowFilePerDatagram) {
                                 break;// this is enough data
                             }
                         } finally {


### PR DESCRIPTION
This pull request shows a possible approach to support "FlowFile per Datagram" for NIFI-548.

Most of the changes are for passing down a flag from the processor all the way to the DatagramChannelReader which requires passing through a few levels of classes.

The important change to the logic is:
* DatagramChannelReader - break out of the receive loop if null, or if we only want one datagram
* UDPConsumerCallback - break out of writing to the FlowFile OutputStream if we hit the totalBytes, or if we only want one datagram
