### PR TITLE
Eliminate hardcoded compression codec classnames for PutHDFS and GetHDFS

### DIFF
--- a/nifi/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
+++ b/nifi/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
@@ -42,13 +42,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.compress.BZip2Codec;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.CompressionCodecFactory;
-import org.apache.hadoop.io.compress.DefaultCodec;
-import org.apache.hadoop.io.compress.GzipCodec;
-import org.apache.hadoop.io.compress.Lz4Codec;
-import org.apache.hadoop.io.compress.SnappyCodec;
 import org.apache.hadoop.net.NetUtils;
 
 /**
@@ -66,13 +59,6 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor {
             .build();
 
     public static final String DIRECTORY_PROP_NAME = "Directory";
-
-    public static final PropertyDescriptor COMPRESSION_CODEC = new PropertyDescriptor.Builder()
-        .name("Compression codec")
-        .required(false)
-        .allowableValues(BZip2Codec.class.getName(), DefaultCodec.class.getName(),
-            GzipCodec.class.getName(), Lz4Codec.class.getName(), SnappyCodec.class.getName())
-        .build();
 
     protected static final List<PropertyDescriptor> properties;
 
@@ -240,24 +226,6 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor {
             }
 
         };
-    }
-
-    /**
-     * Returns the configured CompressionCodec, or null if none is configured.
-     *
-     * @param context the ProcessContext
-     * @param configuration the Hadoop Configuration
-     * @return CompressionCodec or null
-     */
-    protected CompressionCodec getCompressionCodec(ProcessContext context, Configuration configuration) {
-        CompressionCodec codec = null;
-        if (context.getProperty(COMPRESSION_CODEC).isSet()) {
-            String compressionClassname = context.getProperty(COMPRESSION_CODEC).getValue();
-            CompressionCodecFactory ccf = new CompressionCodecFactory(configuration);
-            codec = ccf.getCodecByClassName(compressionClassname);
-        }
-
-        return codec;
     }
 
     /**

--- a/nifi/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/GetHDFSTest.java
+++ b/nifi/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/GetHDFSTest.java
@@ -33,8 +33,6 @@ import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.GzipCodec;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -108,19 +106,6 @@ public class GetHDFSTest {
         for (ValidationResult vr : results) {
             Assert.assertTrue(vr.toString().contains("is invalid because Minimum File Age cannot be greater than Maximum File Age"));
         }
-
-        results = new HashSet<>();
-        runner.setProperty(GetHDFS.DIRECTORY, "/target");
-        runner.setProperty(GetHDFS.COMPRESSION_CODEC, CompressionCodec.class.getName());
-        runner.enqueue(new byte[0]);
-        pc = runner.getProcessContext();
-        if (pc instanceof MockProcessContext) {
-            results = ((MockProcessContext) pc).validate();
-        }
-        Assert.assertEquals(1, results.size());
-        for (ValidationResult vr : results) {
-            Assert.assertTrue(vr.toString().contains("is invalid because Given value not found in allowed set"));
-        }
     }
 
     @Test
@@ -138,18 +123,72 @@ public class GetHDFSTest {
     }
 
     @Test
-    public void testGetFilesWithCompression() throws IOException {
+    public void testInferCompression() throws IOException {
         TestRunner runner = TestRunners.newTestRunner(GetHDFS.class);
         runner.setProperty(PutHDFS.DIRECTORY, "src/test/resources/testdata");
         runner.setProperty(GetHDFS.FILE_FILTER_REGEX, "random.*.gz");
-        runner.setProperty(GetHDFS.COMPRESSION_CODEC, GzipCodec.class.getName());
         runner.setProperty(GetHDFS.KEEP_SOURCE_FILE, "true");
         runner.run();
+
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(GetHDFS.REL_SUCCESS);
         assertEquals(1, flowFiles.size());
+
         MockFlowFile flowFile = flowFiles.get(0);
-        assertTrue(flowFile.getAttribute(CoreAttributes.FILENAME.key()).startsWith("randombytes-1.gz"));
+        assertTrue(flowFile.getAttribute(CoreAttributes.FILENAME.key()).equals("randombytes-1"));
         InputStream expected = getClass().getResourceAsStream("/testdata/randombytes-1");
+        flowFile.assertContentEquals(expected);
+    }
+
+    @Test
+    public void testRetainCompressionFileExt() throws IOException {
+        TestRunner runner = TestRunners.newTestRunner(GetHDFS.class);
+        runner.setProperty(PutHDFS.DIRECTORY, "src/test/resources/testdata");
+        runner.setProperty(GetHDFS.FILE_FILTER_REGEX, "random.*.gz");
+        runner.setProperty(GetHDFS.KEEP_SOURCE_FILE, "true");
+        runner.setProperty(GetHDFS.REMOVE_COMPRESSION_FILE_EXTENSION, "false");
+        runner.run();
+
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(GetHDFS.REL_SUCCESS);
+        assertEquals(1, flowFiles.size());
+
+        MockFlowFile flowFile = flowFiles.get(0);
+        assertTrue(flowFile.getAttribute(CoreAttributes.FILENAME.key()).equals("randombytes-1.gz"));
+        InputStream expected = getClass().getResourceAsStream("/testdata/randombytes-1");
+        flowFile.assertContentEquals(expected);
+    }
+
+    @Test
+    public void testFileNotCompressed() throws IOException {
+        TestRunner runner = TestRunners.newTestRunner(GetHDFS.class);
+        runner.setProperty(PutHDFS.DIRECTORY, "src/test/resources/testdata");
+        runner.setProperty(GetHDFS.FILE_FILTER_REGEX, ".*.zip");
+        runner.setProperty(GetHDFS.KEEP_SOURCE_FILE, "true");
+        runner.run();
+
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(GetHDFS.REL_SUCCESS);
+        assertEquals(1, flowFiles.size());
+
+        MockFlowFile flowFile = flowFiles.get(0);
+        assertTrue(flowFile.getAttribute(CoreAttributes.FILENAME.key()).equals("13545423550275052.zip"));
+        InputStream expected = getClass().getResourceAsStream("/testdata/13545423550275052.zip");
+        flowFile.assertContentEquals(expected);
+    }
+
+    @Test
+    public void testInferCompressionDisabled() throws IOException {
+        TestRunner runner = TestRunners.newTestRunner(GetHDFS.class);
+        runner.setProperty(PutHDFS.DIRECTORY, "src/test/resources/testdata");
+        runner.setProperty(GetHDFS.FILE_FILTER_REGEX, "random.*.gz");
+        runner.setProperty(GetHDFS.KEEP_SOURCE_FILE, "true");
+        runner.setProperty(GetHDFS.INFER_COMPRESSION_CODEC, "false");
+        runner.run();
+
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(GetHDFS.REL_SUCCESS);
+        assertEquals(1, flowFiles.size());
+
+        MockFlowFile flowFile = flowFiles.get(0);
+        assertTrue(flowFile.getAttribute(CoreAttributes.FILENAME.key()).equals("randombytes-1.gz"));
+        InputStream expected = getClass().getResourceAsStream("/testdata/randombytes-1.gz");
         flowFile.assertContentEquals(expected);
     }
 }

--- a/nifi/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
+++ b/nifi/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
@@ -149,7 +149,7 @@ public class PutHDFSTest {
         }
         Assert.assertEquals(1, results.size());
         for (ValidationResult vr : results) {
-            Assert.assertTrue(vr.toString().contains("is invalid because Given value not found in allowed set"));
+            Assert.assertTrue(vr.toString().contains("is invalid because CompressionCodec Class not found"));
         }
     }
 


### PR DESCRIPTION
Removed hardcoded compression codecs from AbstractHadoopProcessor. Allow PutHDFS to discover the available codecs via CompressionCodecFactory, and allow GetHDFS to choose the codec to use based on file extension.