### PR TITLE
NIFI-738: Improve error handling for CSV and JSON conversion.

### DIFF
--- a/nifi/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/src/main/java/org/apache/nifi/processors/kite/FailureTracker.java
+++ b/nifi/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/src/main/java/org/apache/nifi/processors/kite/FailureTracker.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.nifi.processors.kite;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+import java.util.Map;
+
+class FailureTracker {
+    private static final Splitter REASON_SEPARATOR = Splitter.on(':').limit(2);
+
+    private final Map<String, String> examples = Maps.newLinkedHashMap();
+    private final Map<String, Integer> occurrences = Maps.newLinkedHashMap();
+    long count = 0L;
+
+    public void add(Throwable throwable) {
+        add(reason(throwable));
+    }
+
+    public void add(String reason) {
+        count += 1;
+        String problem = Iterators.getNext(REASON_SEPARATOR.split(reason).iterator(), "Unknown");
+        if (examples.containsKey(problem)) {
+            occurrences.put(problem, occurrences.get(problem) + 1);
+        } else {
+            examples.put(problem, reason);
+            occurrences.put(problem, 1);
+        }
+    }
+
+    public long count() {
+        return count;
+    }
+
+    public String summary() {
+        boolean first = true;
+        StringBuilder sb = new StringBuilder();
+        for (String problem : examples.keySet()) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append(examples.get(problem));
+            int similar = occurrences.get(problem) - 1;
+            if (similar == 1) {
+                sb.append(" (1 similar failure)");
+            } else if (similar > 1) {
+                sb.append(" (").append(similar).append(" similar failures)");
+            }
+        }
+        return sb.toString();
+    }
+
+    private static String reason(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        for (Throwable current = t; current != null; current = current.getCause()) {
+            if (current != t) {
+                sb.append(": ");
+            }
+            sb.append(current.getMessage());
+        }
+        return sb.toString();
+    }
+}

--- a/nifi/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/src/test/java/org/apache/nifi/processors/kite/TestJSONToAvroProcessor.java
+++ b/nifi/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/src/test/java/org/apache/nifi/processors/kite/TestJSONToAvroProcessor.java
@@ -19,10 +19,11 @@
 package org.apache.nifi.processors.kite;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
-import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.Assert;
@@ -41,11 +42,18 @@ public class TestJSONToAvroProcessor {
     public static final String JSON_CONTENT = ""
             + "{\"id\": 1,\"color\": \"green\"}"
             + "{\"id\": \"120V\", \"color\": \"blue\"}\n" // invalid, ID is a string
-            + "{\"id\": 10, \"color\": 15.23}\n" + // invalid, color as double
-            "{\"id\": 2, \"color\": \"grey\", \"price\": 12.95 }";
+            + "{\"id\": 10, \"color\": 15.23}\n" // invalid, color as double
+            + "{\"id\": 20, \"color\": 34}\n" // invalid, color as int
+            + "{\"id\": 2, \"color\": \"grey\", \"price\": 12.95 }";
 
-    public static final String FAILURE_CONTENT = "Cannot convert field id [Cannot convert to long: \"120V\"]\n"
-            + "Cannot convert field color [Cannot convert to string: 15.23]\n";
+    public static final String FAILURE_CONTENT = ""
+            + "{\"id\": \"120V\", \"color\": \"blue\"}\n"
+            + "{\"id\": 10, \"color\": 15.23}\n"
+            + "{\"id\": 20, \"color\": 34}\n";
+
+    public static final String FAILURE_SUMMARY = ""
+            + "Cannot convert field id: Cannot convert to long: \"120V\", "
+            + "Cannot convert field color: Cannot convert to string: 15.23 (1 similar failure)";
 
     @Test
     public void testBasicConversion() throws IOException {
@@ -60,13 +68,88 @@ public class TestJSONToAvroProcessor {
         long converted = runner.getCounterValue("Converted records");
         long errors = runner.getCounterValue("Conversion errors");
         Assert.assertEquals("Should convert 2 rows", 2, converted);
-        Assert.assertEquals("Should reject 2 rows", 2, errors);
+        Assert.assertEquals("Should reject 3 rows", 3, errors);
 
         runner.assertTransferCount("success", 1);
-        runner.assertTransferCount("failure", 1);
+        runner.assertTransferCount("failure", 0);
+        runner.assertTransferCount("incompatible", 1);
 
-        String failureContent = Bytes.toString(runner.getContentAsByteArray(
-                runner.getFlowFilesForRelationship("failure").get(0)));
-        Assert.assertEquals("Should reject an invalid string and double", FAILURE_CONTENT, failureContent);
+        MockFlowFile incompatible = runner.getFlowFilesForRelationship("incompatible").get(0);
+        String failureContent = new String(runner.getContentAsByteArray(incompatible),
+                StandardCharsets.UTF_8);
+        Assert.assertEquals("Should reject an invalid string and double",
+                JSON_CONTENT, failureContent);
+        Assert.assertEquals("Should accumulate error messages",
+                FAILURE_SUMMARY, incompatible.getAttribute("errors"));
+    }
+
+    @Test
+    public void testOnlyErrors() throws IOException {
+        TestRunner runner = TestRunners.newTestRunner(ConvertJSONToAvro.class);
+        runner.assertNotValid();
+        runner.setProperty(ConvertJSONToAvro.SCHEMA, SCHEMA.toString());
+        runner.assertValid();
+
+        runner.enqueue(streamFor(FAILURE_CONTENT));
+        runner.run();
+
+        long converted = runner.getCounterValue("Converted records");
+        long errors = runner.getCounterValue("Conversion errors");
+        Assert.assertEquals("Should convert 0 rows", 0, converted);
+        Assert.assertEquals("Should reject 1 row", 3, errors);
+
+        runner.assertTransferCount("success", 0);
+        runner.assertTransferCount("failure", 1);
+        runner.assertTransferCount("incompatible", 0);
+
+        MockFlowFile incompatible = runner.getFlowFilesForRelationship("failure").get(0);
+        Assert.assertEquals("Should set an error message",
+                FAILURE_SUMMARY, incompatible.getAttribute("errors"));
+    }
+
+    @Test
+    public void testEmptyContent() throws IOException {
+        TestRunner runner = TestRunners.newTestRunner(ConvertJSONToAvro.class);
+        runner.assertNotValid();
+        runner.setProperty(ConvertJSONToAvro.SCHEMA, SCHEMA.toString());
+        runner.assertValid();
+
+        runner.enqueue(streamFor(""));
+        runner.run();
+
+        long converted = runner.getCounterValue("Converted records");
+        long errors = runner.getCounterValue("Conversion errors");
+        Assert.assertEquals("Should convert 0 rows", 0, converted);
+        Assert.assertEquals("Should reject 0 row", 0, errors);
+
+        runner.assertTransferCount("success", 0);
+        runner.assertTransferCount("failure", 1);
+        runner.assertTransferCount("incompatible", 0);
+
+        MockFlowFile incompatible = runner.getFlowFilesForRelationship("failure").get(0);
+        Assert.assertEquals("Should set an error message",
+                "No incoming records", incompatible.getAttribute("errors"));
+    }
+
+    @Test
+    public void testBasicConversionNoErrors() throws IOException {
+        TestRunner runner = TestRunners.newTestRunner(ConvertJSONToAvro.class);
+        runner.assertNotValid();
+        runner.setProperty(ConvertJSONToAvro.SCHEMA, SCHEMA.toString());
+        runner.assertValid();
+
+        runner.enqueue(streamFor(
+                "{\"id\": 1,\"color\": \"green\"}\n" +
+                        "{\"id\": 2, \"color\": \"grey\", \"price\": 12.95 }"));
+        runner.run();
+
+        long converted = runner.getCounterValue("Converted records");
+        long errors = runner.getCounterValue("Conversion errors");
+        Assert.assertEquals("Should convert 2 rows", 2, converted);
+        Assert.assertEquals("Should reject 0 row", 0, errors);
+
+        runner.assertTransferCount("success", 1);
+        runner.assertTransferCount("failure", 0);
+        runner.assertTransferCount("incompatible", 0);
     }
 }


### PR DESCRIPTION
Changes:
* Send bad record information on the "incompatible" relationship
* Use an attribute, "errors" for summarized error messages
* Send no error content for now, original content can't be accessed
* Summarize similar error messages with "N similar failures"
* Add similar error handling to CSV conversion